### PR TITLE
Update inventek-bsp-manifest-fv2.xml

### DIFF
--- a/inventek-bsp-manifest-fv2.xml
+++ b/inventek-bsp-manifest-fv2.xml
@@ -1,7 +1,7 @@
 <boards>
   <board default_location="local">
     <id>ISM43439-WBP-L151-EVB</id>
-    <category>PSoC&#8482; 6 BSPs</category>
+    <category>PSOC&#8482; 6 BSPs</category>
     <board_uri>https://github.com/Inventek/TARGET_ISM43439-WBP-L151-EVB</board_uri>
     <chips>
       <mcu>ISM43439-WBP-L151 (CY8C6248FNI-S2D43)</mcu>
@@ -9,12 +9,12 @@
     </chips>
     <name>ISM43439-WBP-L151-EVB</name>
     <summary><![CDATA[
-    The ISM43439-WBP-L151-EVB Evaluation Kit enables you to evaluate and develop applications using PSoC&#8482; 62 (CY8C6248FNI-S2D43T) MCU. The evaluation kit features a AIROC&#8482; CYW43439 Wi-Fi/Bluetooth&#174; combo devices. It comes with on-board debugger/programmer with KitProg3, Infineon 512-Mb(S25FL512SAGMFI010) Quad-SPI NOR flash.
+    The ISM43439-WBP-L151-EVB Evaluation Kit enables you to evaluate and develop applications using PSOC&#8482; 62 (CY8C6248FNI-S2D43T) MCU. The evaluation kit features a AIROC&#8482; CYW43439 Wi-Fi/Bluetooth&#174; combo devices. It comes with on-board debugger/programmer with KitProg3, Infineon 512-Mb(S25FL512SAGMFI010) Quad-SPI NOR flash.
     <p><b>Note:</b></p>
-    <p>ISM43439-WBP-L151-EVB is the board support package for the ISM43439-WBP-L151 SIP which has a PSoC&#8482; 62 (CY8C6248FNI-S2D43T) in combination with the CYW43439 radio and supports PSoC&#8482; 6 MCU examples and Wi-Fi/Bluetooth&#174; connectivity examples.</p>
+    <p>ISM43439-WBP-L151-EVB is the board support package for the ISM43439-WBP-L151 SIP which has a PSOC&#8482; 62 (CY8C6248FNI-S2D43T) in combination with the CYW43439 radio and supports PSOC&#8482; 6 MCU examples and Wi-Fi/Bluetooth&#174; connectivity examples.</p>
     ]]></summary>
     <prov_capabilities>adc anycloud bt button cat1 cat1a comp csd cyw43439 cyw43xxx dma flash_1024k hal i2c i2s ism43439_wbp_l151_evb led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash pdm psoc6 qspi rtc sdhc smart_io spi sram_512k std_crypto switch uart usb_device usb_host wifi</prov_capabilities>
-    <description>        &lt;div class="category"&gt;Kit Features:&lt;/div&gt;         &lt;ul&gt;         &lt;li&gt;Support of up to 1MB Flash and 512KB SRAM&lt;/li&gt;         &lt;li&gt;Delivers dual-cores, with a 150-MHz Arm&amp;#174; Cortex&amp;#174;-M4 as the primary application processor and a 100-MHz Arm&amp;#174; Cortex&amp;#174;-M0+ as the secondary processor for low-power operations.&lt;/li&gt;         &lt;li&gt;Supports Full-Speed USB, a Quad- SPI interface, 13 serial communication blocks, 7 programmable analog blocks, and 56 programmable digital blocks.&lt;/li&gt;         &lt;/ul&gt;&lt;p/&gt;         &lt;div class="category"&gt;Kit Contents:&lt;/div&gt;         &lt;ul&gt;         &lt;li&gt;ISM43439-WBP-L151-EVB&#8482; Evaluation Board (PSoC&#8482; CY8C6248FNI-S2D43T MCU + CYW43439 Wi-Fi/Bluetooth&amp;#174; Radio)&lt;/li&gt;         &lt;li&gt;USB Type-A to Micro-B cable&lt;/li&gt;         &lt;li&gt;Quick start guide&lt;/li&gt;         &lt;/ul&gt;</description>
+    <description>        &lt;div class="category"&gt;Kit Features:&lt;/div&gt;         &lt;ul&gt;         &lt;li&gt;Support of up to 1MB Flash and 512KB SRAM&lt;/li&gt;         &lt;li&gt;Delivers dual-cores, with a 150-MHz Arm&amp;#174; Cortex&amp;#174;-M4 as the primary application processor and a 100-MHz Arm&amp;#174; Cortex&amp;#174;-M0+ as the secondary processor for low-power operations.&lt;/li&gt;         &lt;li&gt;Supports Full-Speed USB, a Quad- SPI interface, 13 serial communication blocks, 7 programmable analog blocks, and 56 programmable digital blocks.&lt;/li&gt;         &lt;/ul&gt;&lt;p/&gt;         &lt;div class="category"&gt;Kit Contents:&lt;/div&gt;         &lt;ul&gt;         &lt;li&gt;ISM43439-WBP-L151-EVB&#8482; Evaluation Board (PSOC&#8482; CY8C6248FNI-S2D43T MCU + CYW43439 Wi-Fi/Bluetooth&amp;#174; Radio)&lt;/li&gt;         &lt;li&gt;USB Type-A to Micro-B cable&lt;/li&gt;         &lt;li&gt;Quick start guide&lt;/li&gt;         &lt;/ul&gt;</description>
     <documentation_url>https://github.com/Inventek/mtb_docs/blob/main/ISM43439-WBP-L151-EVB.pdf</documentation_url>
     <versions>
       <version tools_min_version="3.0.0" flow_version="2.0" prov_capabilities_per_version="bsp_gen4">


### PR DESCRIPTION
Infineon is updating the branding from PSoC to PSOC.  This change updates the categories as displayed within ModusToolbox Project Creator to align with uppercase PSOC.